### PR TITLE
feat: support @kortex-hub/mcp-registry-types 1.2.3

### DIFF
--- a/packages/mcp-manager/package.json
+++ b/packages/mcp-manager/package.json
@@ -22,7 +22,7 @@
     "vite": "^7.1.3",
     "vitest": "^3.0.9",
     "vite-plugin-dts": "^4.5.4",
-    "@kortex-hub/mcp-registry-types": "^1.1.0",
+    "@kortex-hub/mcp-registry-types": "^1.2.3",
     "@kortex-hub/mcp-registry-client": "workspace:*",
     "@kortex-hub/mcp-runner": "workspace:*"
   },

--- a/packages/mcp-manager/src/models/base-config.ts
+++ b/packages/mcp-manager/src/models/base-config.ts
@@ -26,10 +26,6 @@ export interface BaseConfig {
      */
     type: 'remote' | 'package';
     /**
-     * The server identifier from {@link import('@kortex-hub/mcp-registry-types').components.schemas.ServerDetail._meta["io.modelcontextprotocol.registry/official"].serverId}
-     */
-    serverId: string;
-    /**
      * The semantic version of the server from {@link import('@kortex-hub/mcp-registry-types').components.schemas.Server.version}
      */
     version: string;

--- a/packages/mcp-registry-client/package.json
+++ b/packages/mcp-registry-client/package.json
@@ -19,7 +19,7 @@
     "vite": "^7.1.3",
     "vitest": "^3.0.9",
     "vite-plugin-dts": "^4.5.4",
-    "@kortex-hub/mcp-registry-types": "^1.1.0"
+    "@kortex-hub/mcp-registry-types": "^1.2.3"
   },
   "files": [
     "dist"

--- a/packages/mcp-registry-client/src/mcp-registry-client.spec.ts
+++ b/packages/mcp-registry-client/src/mcp-registry-client.spec.ts
@@ -28,7 +28,6 @@ const SERVER_LIST_EMPTY: components['schemas']['ServerList'] = {
 const SERVER_DETAILS: components['schemas']['Server'] = {
     name: 'foo',
     description: 'bar',
-    status: 'active',
     version: '1.0.0'
 }
 
@@ -92,7 +91,7 @@ describe('getServers', () => {
 });
 
 interface GetServerTestCase {
-    parameters: paths['/v0/servers/{server_id}']['get']['parameters'],
+    parameters: paths['/v0/servers/{serverName}']['get']['parameters'],
     expectedURL: string,
 }
 
@@ -103,12 +102,12 @@ describe('getServer', () => {
 
     test.each<GetServerTestCase>([
         {
-            parameters: { path: { server_id: 'foo' }, query: {} },
+            parameters: { path: { serverName: encodeURI('foo') } },
             expectedURL: `${MCP_REGISTRY_BASE_URL}/v0/servers/foo`
         },
         {
-            parameters: { path: { server_id: 'bar' }, query: { version: '1.0.0' } },
-            expectedURL: `${MCP_REGISTRY_BASE_URL}/v0/servers/bar?version=1.0.0`
+            parameters: { path: { serverName: encodeURI('bar') } },
+            expectedURL: `${MCP_REGISTRY_BASE_URL}/v0/servers/bar`
         },
     ])('should call fetch with correct URL for parameters $parameters', async ({ parameters, expectedURL }) => {
         const client = new MCPRegistryClient({ fetch: FETCH_MOCK });
@@ -117,4 +116,54 @@ describe('getServer', () => {
     });
 });
 
+interface GetServerVersionsTestCase {
+    parameters: paths['/v0/servers/{serverName}/versions']['get']['parameters'],
+    expectedURL: string,
+}
 
+describe('getServers', () => {
+    beforeEach(() => {
+        vi.mocked(RESPONSE_MOCK.json).mockResolvedValue(SERVER_DETAILS);
+    });
+
+    test.each<GetServerVersionsTestCase>([
+        {
+            parameters: { path: { serverName: encodeURI('foo') } },
+            expectedURL: `${MCP_REGISTRY_BASE_URL}/v0/servers/foo/versions`
+        },
+        {
+            parameters: { path: { serverName: encodeURI('bar') } },
+            expectedURL: `${MCP_REGISTRY_BASE_URL}/v0/servers/bar/versions`
+        },
+    ])('should call fetch with correct URL for parameters $parameters', async ({ parameters, expectedURL }) => {
+        const client = new MCPRegistryClient({ fetch: FETCH_MOCK });
+        await client.getServerVersions(parameters);
+        expect(FETCH_MOCK).toHaveBeenCalledWith(expectedURL);
+    });
+});
+
+interface GetServerVersionTestCase {
+    parameters: paths['/v0/servers/{serverName}/versions/{version}']['get']['parameters'],
+    expectedURL: string,
+}
+
+describe('getServerVersion', () => {
+    beforeEach(() => {
+        vi.mocked(RESPONSE_MOCK.json).mockResolvedValue(SERVER_DETAILS);
+    });
+
+    test.each<GetServerVersionTestCase>([
+        {
+            parameters: { path: { serverName: encodeURI('foo'), version: encodeURI('1.0.5') } },
+            expectedURL: `${MCP_REGISTRY_BASE_URL}/v0/servers/foo/versions/1.0.5`
+        },
+        {
+            parameters: { path: { serverName: encodeURI('bar'), version: encodeURI('2.8.3') } },
+            expectedURL: `${MCP_REGISTRY_BASE_URL}/v0/servers/bar/versions/2.8.3`
+        },
+    ])('should call fetch with correct URL for parameters $parameters', async ({ parameters, expectedURL }) => {
+        const client = new MCPRegistryClient({ fetch: FETCH_MOCK });
+        await client.getServerVersion(parameters);
+        expect(FETCH_MOCK).toHaveBeenCalledWith(expectedURL);
+    });
+});

--- a/packages/mcp-registry-client/src/mcp-registry-client.ts
+++ b/packages/mcp-registry-client/src/mcp-registry-client.ts
@@ -75,12 +75,11 @@ export class MCPRegistryClient {
         });
         const response = await this.#fetch(resolvedURL);
         if(!response.ok) throw new Error(`Failed to fetch servers for registry ${this.#baseURL}: ${response.statusText} - (URL: ${resolvedURL})`);
-        const body = await response.json()
-        return body as components['schemas']['ServerList'];
+        return (await response.json()) as paths['/v0/servers']['get']['responses'][200]['content']['application/json'];
     }
 
-    public async getServer(parameters: paths['/v0/servers/{server_id}']['get']['parameters']): Promise<components['schemas']['ServerDetail']> {
-        const resolvedURL = this.getURL('/v0/servers/{server_id}', {
+    public async getServer(parameters: paths['/v0/servers/{serverName}']['get']['parameters']): Promise<components['schemas']['ServerResponse']> {
+        const resolvedURL = this.getURL('/v0/servers/{serverName}', {
             queries: parameters.query ? this.filterUndefined(parameters.query) : undefined,
             paths: parameters.path ? this.filterUndefined(parameters.path) : undefined,
         });
@@ -88,19 +87,30 @@ export class MCPRegistryClient {
             resolvedURL,
         );
         if(!response.ok) throw new Error(`Failed to fetch server details for registry ${this.#baseURL}: ${response.statusText} - (URL: ${resolvedURL})`);
-        const body = await response.json()
-        return body as components['schemas']['ServerDetail'];
+        return (await response.json()) as paths['/v0/servers/{serverName}']['get']['responses'][200]['content']['application/json'];
     }
 
-    public async getServerVersions(parameters: paths['/v0/servers/{server_id}']['get']['parameters']): Promise<components['schemas']['ServerList']> {
+    public async getServerVersions(parameters: paths['/v0/servers/{serverName}/versions']['get']['parameters']): Promise<components['schemas']['ServerList']> {
         const response = await this.#fetch(
-            this.getURL('/v0/servers/{server_id}', {
+            this.getURL('/v0/servers/{serverName}/versions', {
                 queries: parameters.query ? this.filterUndefined(parameters.query) : undefined,
                 paths: parameters.path ? this.filterUndefined(parameters.path) : undefined,
             }),
         );
         if(!response.ok) throw new Error(`Failed to fetch server versions for registry ${this.#baseURL}: ${response.statusText}`);
-        const body = await response.json()
-        return body as components['schemas']['ServerList'];
+        return (await response.json()) as paths['/v0/servers/{serverName}/versions']['get']['responses'][200]['content']['application/json'];
+    }
+
+    public async getServerVersion(
+        parameters: paths['/v0/servers/{serverName}/versions/{version}']['get']['parameters']
+    ): Promise<components['schemas']['ServerResponse']> {
+        const response = await this.#fetch(
+            this.getURL('/v0/servers/{serverName}/versions/{version}', {
+                queries: parameters.query ? this.filterUndefined(parameters.query) : undefined,
+                paths: parameters.path ? this.filterUndefined(parameters.path) : undefined,
+            }),
+        );
+        if(!response.ok) throw new Error(`Failed to fetch server versions for registry ${this.#baseURL}: ${response.statusText}`);
+        return (await response.json()) as paths['/v0/servers/{serverName}/versions/{version}']['get']['responses'][200]['content']['application/json'];
     }
 }

--- a/packages/mcp-runner/package.json
+++ b/packages/mcp-runner/package.json
@@ -22,7 +22,7 @@
     "vite": "^7.1.3",
     "vitest": "^3.0.9",
     "vite-plugin-dts": "^4.5.4",
-    "@kortex-hub/mcp-registry-types": "^1.1.0",
+    "@kortex-hub/mcp-registry-types": "^1.2.3",
     "@kortex-hub/mcp-registry-client": "workspace:*",
     "ai": "^5.0.59"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: workspace:*
         version: link:../mcp-registry-client
       '@kortex-hub/mcp-registry-types':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.3
+        version: 1.2.3
       '@kortex-hub/mcp-runner':
         specifier: workspace:*
         version: link:../mcp-runner
@@ -58,8 +58,8 @@ importers:
   packages/mcp-registry-client:
     devDependencies:
       '@kortex-hub/mcp-registry-types':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.3
+        version: 1.2.3
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -83,8 +83,8 @@ importers:
         specifier: workspace:*
         version: link:../mcp-registry-client
       '@kortex-hub/mcp-registry-types':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.3
+        version: 1.2.3
       ai:
         specifier: ^5.0.59
         version: 5.0.59(zod@3.25.76)
@@ -329,8 +329,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kortex-hub/mcp-registry-types@1.1.0':
-    resolution: {integrity: sha512-V1z/J8MXajEb/UFBYgS8QWVj4+X3KoSSSMkehziJU2j3rDkQkO7J9vfqgesze46mpuu7LJ0yFAkUcTlZ2xrY+A==}
+  '@kortex-hub/mcp-registry-types@1.2.3':
+    resolution: {integrity: sha512-vNVgNt10al3RZsIUwf3VrZl+7qeyDhoNU3VSTLS5K0caXbbuP3KZWzNBDUHZ891oHOX2glXjJSnReOuD5GO/Dw==}
 
   '@microsoft/api-extractor-model@7.30.7':
     resolution: {integrity: sha512-TBbmSI2/BHpfR9YhQA7nH0nqVmGgJ0xH0Ex4D99/qBDAUpnhA2oikGmdXanbw9AWWY/ExBYIpkmY8dBHdla3YQ==}
@@ -1621,7 +1621,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kortex-hub/mcp-registry-types@1.1.0': {}
+  '@kortex-hub/mcp-registry-types@1.2.3': {}
 
   '@microsoft/api-extractor-model@7.30.7(@types/node@24.6.1)':
     dependencies:


### PR DESCRIPTION
- Supporting latest 1.2.3 registry types
- Adding new version method